### PR TITLE
Define inert property immediately, before onload

### DIFF
--- a/inert-polyfill.js
+++ b/inert-polyfill.js
@@ -263,17 +263,16 @@ window.addEventListener('load', function() {
       ev.stopPropagation();
     }
   }, true);
+});
 
-  var inertOpts = {
-    enumerable: true,
-    get: function() { return this.hasAttribute('inert'); },
-    set: function(inert) {
-      if (inert) {
-        this.setAttribute('inert', '');
-      } else {
-        this.removeAttribute('inert');
-      }
+Object.defineProperty(Element.prototype, 'inert', {
+  enumerable: true,
+  get: function() { return this.hasAttribute('inert'); },
+  set: function(inert) {
+    if (inert) {
+      this.setAttribute('inert', '');
+    } else {
+      this.removeAttribute('inert');
     }
-  };
-  Object.defineProperty(Element.prototype, 'inert', inertOpts);
+  }
 });


### PR DESCRIPTION
Element.inert now works immediately after loading the polyfill.

Fixes #5.